### PR TITLE
Minimum Changes for Amazon Linux 1 & 2 (Latest) to Both Function

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -228,6 +228,29 @@ platforms:
 #      http_proxy: <%= ENV['http_proxy']%>
 #      https_proxy: <%= ENV['https_proxy']%>
 #      no_proxy: <%= ENV['no_proxy']%>
+      run_command: /usr/sbin/init
+      privileged: true
+      provision_command:
+        - systemctl enable sshd.service
+
+  - name: amazon1-docker
+    driver:
+      name: docker
+      use_sudo: false # For Native Docker on Mac. Remove/Comment if using Toolbox (docker-machine)
+      image: amazonlinux:2018.03
+      platform: rhel
+      provision_command:
+#        - echo "export http_proxy=<%= ENV['http_proxy']%>" > /etc/profile.d/proxy.sh
+#        - echo "export https_proxy=<%= ENV['https_proxy']%>" >> /etc/profile.d/proxy.sh
+#        - echo "export no_proxy=<%= ENV['no_proxy']%>" >> /etc/profile.d/proxy.sh
+#        - export http_proxy="<%= ENV['http_proxy']%>"
+#        - export https_proxy="<%= ENV['https_proxy']%>"
+#        - export no_proxy="<%= ENV['no_proxy']%>"
+        - yum -y install upstart procps util-linux
+      ssl_verify_mode: ":verify_none"
+#      http_proxy: <%= ENV['http_proxy']%>
+#      https_proxy: <%= ENV['https_proxy']%>
+#      no_proxy: <%= ENV['no_proxy']%>
 
 suites:
   - name: ec2_base
@@ -306,7 +329,7 @@ suites:
       bonusbits_base:
         deployment_location: 'circleci'
       <% end %>
-    includes: ["amazon-docker"]
+    includes: ["amazon-docker","amazon1-docker"]
 
   - name: docker_base_java
     run_list:

--- a/Berksfile.lock
+++ b/Berksfile.lock
@@ -10,7 +10,7 @@ GRAPH
   apt (6.1.3)
   audit (4.2.0)
     compat_resource (>= 0.0.0)
-  bonusbits_base (2.2.5)
+  bonusbits_base (2.3.0)
     apt (>= 0.0.0)
     audit (>= 0.0.0)
     bonusbits_library (>= 0.0.0)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM amazonlinux:latest
+FROM amazonlinux:2018.03
 MAINTAINER Levon Becker "levon.docker@bonusbits.com"
 LABEL version="2.1.10" \
       description="Amazon Linux Image built from bonusbits_base cookbook." \

--- a/Gemfile
+++ b/Gemfile
@@ -24,4 +24,5 @@ group :integration do
   gem 'kitchen-ec2', '~> 1.3'
   gem 'kitchen-inspec', '~> 0.17'
   gem 'test-kitchen', '~> 1.16'
+  gem 'safe_yaml', '1.0.5'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -281,7 +281,7 @@ GEM
     rubyntlm (0.6.1)
     rubyzip (1.2.1)
     rufus-lru (1.1.0)
-    safe_yaml (1.0.4)
+    safe_yaml (1.0.5)
     sawyer (0.8.1)
       addressable (>= 2.3.5, < 2.6)
       faraday (~> 0.8, < 1.0)
@@ -368,7 +368,8 @@ DEPENDENCIES
   rake (~> 10.5)
   rspec_junit_formatter (~> 0.2.3)
   rubocop (~> 0.47.1)
+  safe_yaml (= 1.0.5)
   test-kitchen (~> 1.16)
 
 BUNDLED WITH
-   1.12.5
+   1.17.2

--- a/attributes/packages.rb
+++ b/attributes/packages.rb
@@ -17,6 +17,25 @@ default['bonusbits_base']['packages'].tap do |packages|
     openssl
     procps
     sudo
+    util-linux
+    vim-enhanced
+    which
+  )
+
+  packages['amazon1']['packages'] = %w(
+    aws-cli
+    ca-certificates
+    curl
+    git
+    gzip
+    htop
+    mlocate
+    net-tools
+    openssh-clients
+    openssh-server
+    openssl
+    procps
+    sudo
     upstart
     util-linux
     vim-enhanced

--- a/recipes/bash_profile.rb
+++ b/recipes/bash_profile.rb
@@ -1,7 +1,8 @@
 case node['platform']
 when 'amazon'
   # Install Update Message of the Day Package
-  package %w(update-motd lolcat)
+  package %w(update-motd)
+  gem_package 'lolcat'
 
   # '/etc/cron.d/update-motd'
   # 'root /sbin/start --quiet update-motd'

--- a/recipes/packages.rb
+++ b/recipes/packages.rb
@@ -1,4 +1,5 @@
 # Package Lists
+amazon1_packages = node['bonusbits_base']['packages']['amazon1']['packages']
 amazon_packages = node['bonusbits_base']['packages']['amazon']['packages']
 debian_packages = node['bonusbits_base']['packages']['debian']['packages']
 redhat_packages = node['bonusbits_base']['packages']['redhat']['packages']
@@ -27,7 +28,12 @@ when 'debian', 'ubuntu'
 when 'redhat', 'centos'
   package redhat_packages
 when 'amazon'
-  package amazon_packages
+  case node['platform_version']
+  when '2'
+    package amazon_packages
+  when '1'
+    package amazon1_packages
+  end
 when 'suse', 'opensuse'
   package suse_packages
 else


### PR DESCRIPTION
Not necessarily a pull request so much as a "here's what I did".

This is the minimum change I could make to permit at least the kitchen to function with docker-base-amazon-docker.

This splits:
Amazon Linux 2: amazon-base-amazon-docker
Amazon Linux 1: amazon-base-amazon1-docker

On the premise that from a docker tagging perspective "latest" Amazon Linux means Amazon Linux 2 and Amazon Linux one is now the special case.