### PR TITLE
v3.0.3

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -9,104 +9,184 @@ platforms:
   # AWS AMI/EC2 Platforms
   - name: amazon-linux1-ami
     driver:
-      associate_public_ip: <%= ENV.fetch('AWS_PUBLIC_IP', 'false') %>
-      aws_ssh_key_id: <%= ENV.fetch('AWS_SSH_KEY_ID', 'bonusbits_dev_key') %>
-      iam_profile_name: <%= ENV.fetch('AWS_IAM_INSTANCE_PROFILE_LNX', 'Linux-Instance_Role') %>
+      associate_public_ip: <%= ENV['AWS_PUBLIC_IP'] %>
+      aws_ssh_key_id: <%= ENV['AWS_SSH_KEY_ID'] %>
+      iam_profile_name: <%= ENV['AWS_IAM_INSTANCE_PROFILE_1'] %>
       image_search:
         owner-id: 137112412989
-        name: amzn-ami-hvm-2018.03.0.20190826-x86_64-gp2
+        name: amzn-ami-hvm-2018.03.0.20210721.0-x86_64-gp2
       instance_initiated_shutdown_behavior: terminate
-      instance_type: t3.micro
+      instance_type: t3.small
       name: ec2
-      region: <%= ENV.fetch('AWS_REGION', 'us-west-2') %>
+      region: <%= ENV['AWS_REGION'] %>
       security_group_ids:
-        - <%= ENV.fetch('AWS_SECURITY_GROUP_lnx_1', 'sg-00000000') %>
-        - <%= ENV.fetch('AWS_SECURITY_GROUP_lnx_2', 'sg-00000000') %>
-      subnet_id: <%= ENV.fetch('AWS_SUBNET_ID', 'subnet-00000000') %>
+        - <%= ENV['AWS_SECURITY_GROUP_1'] %>
+        <% if ENV['AWS_SECURITY_GROUP_2'] %>
+        - <%= ENV['AWS_SECURITY_GROUP_2'] %>
+        <% end %>
+        <% if ENV['AWS_SECURITY_GROUP_3'] %>
+        - <%= ENV['AWS_SECURITY_GROUP_3'] %>
+        <% end %>
+        <% if ENV['AWS_SECURITY_GROUP_4'] %>
+        - <%= ENV['AWS_SECURITY_GROUP_4'] %>
+        <% end %>
+        <% if ENV['AWS_SECURITY_GROUP_5'] %>
+        - <%= ENV['AWS_SECURITY_GROUP_5'] %>
+        <% end %>
+      subnet_id: <%= ENV['AWS_SUBNET_ID'] %>
       tags:
         Created-By: Test Kitchen
         OS: Amazon v1
         Owner: *aws_tag_owner
       # user_data: *bootstrap_lnx
-      vpc_id: <%= ENV.fetch('AWS_VPC_ID', 'vpc-00000000') %>
+      vpc_id: <%= ENV['AWS_VPC_ID'] %>
     transport:
       username: ec2-user
-      ssh_key: <%= ENV.fetch('AWS_SSH_KEY_PATH', ENV['HOME'] + "/.ssh/bonusbits_dev_key.pem") %>
+      ssh_key: <%= ENV['AWS_SSH_KEY_PATH'] %>
   - name: amazon-linux2-ami
     driver:
-      associate_public_ip: <%= ENV.fetch('AWS_PUBLIC_IP', 'false') %>
-      aws_ssh_key_id: <%= ENV.fetch('AWS_SSH_KEY_ID', 'bonusbits_dev_key') %>
-      iam_profile_name: <%= ENV.fetch('AWS_IAM_INSTANCE_PROFILE_LNX', 'Linux-Instance_Role') %>
+      associate_public_ip: <%= ENV['AWS_PUBLIC_IP'] %>
+      aws_ssh_key_id: <%= ENV['AWS_SSH_KEY_ID'] %>
+      iam_profile_name: <%= ENV['AWS_IAM_INSTANCE_PROFILE_1'] %>
       image_search:
         owner-id: 137112412989
-        name: amzn2-ami-hvm-2.0.20190823.1-x86_64-gp2
+        name: amzn2-ami-hvm-2.0.20210813.1-x86_64-gp2
       instance_initiated_shutdown_behavior: terminate
-      instance_type: t3.micro
+      instance_type: t3.small
       name: ec2
-      region: <%= ENV.fetch('AWS_REGION', 'us-west-2') %>
+      region: <%= ENV['AWS_REGION'] %>
       security_group_ids:
-        - <%= ENV.fetch('AWS_SECURITY_GROUP_lnx_1', 'sg-00000000') %>
-        - <%= ENV.fetch('AWS_SECURITY_GROUP_lnx_2', 'sg-00000000') %>
-      subnet_id: <%= ENV.fetch('AWS_SUBNET_ID', 'subnet-00000000') %>
+        - <%= ENV['AWS_SECURITY_GROUP_1'] %>
+        <% if ENV['AWS_SECURITY_GROUP_2'] %>
+        - <%= ENV['AWS_SECURITY_GROUP_2'] %>
+        <% end %>
+        <% if ENV['AWS_SECURITY_GROUP_3'] %>
+        - <%= ENV['AWS_SECURITY_GROUP_3'] %>
+        <% end %>
+        <% if ENV['AWS_SECURITY_GROUP_4'] %>
+        - <%= ENV['AWS_SECURITY_GROUP_4'] %>
+        <% end %>
+        <% if ENV['AWS_SECURITY_GROUP_5'] %>
+        - <%= ENV['AWS_SECURITY_GROUP_5'] %>
+        <% end %>
+      subnet_id: <%= ENV['AWS_SUBNET_ID'] %>
       tags:
         Created-By: Test Kitchen
         OS: Amazon v2
         Owner: *aws_tag_owner
       # user_data: *bootstrap_lnx
-      vpc_id: <%= ENV.fetch('AWS_VPC_ID', 'vpc-00000000') %>
+      vpc_id: <%= ENV['AWS_VPC_ID'] %>
     transport:
       username: ec2-user
-      ssh_key: <%= ENV.fetch('AWS_SSH_KEY_PATH', ENV['HOME'] + "/.ssh/bonusbits_dev_key.pem") %>
+      ssh_key: <%= ENV['AWS_SSH_KEY_PATH'] %>
   - name: ubuntu-1604-ami
     driver:
-      associate_public_ip: <%= ENV.fetch('AWS_PUBLIC_IP', 'false') %>
-      aws_ssh_key_id: <%= ENV.fetch('AWS_SSH_KEY_ID', 'bonusbits_dev_key') %>
-      iam_profile_name: <%= ENV.fetch('AWS_IAM_INSTANCE_PROFILE_LNX', 'Linux-Instance_Role') %>
+      associate_public_ip: <%= ENV['AWS_PUBLIC_IP'] %>
+      aws_ssh_key_id: <%= ENV['AWS_SSH_KEY_ID'] %>
+      iam_profile_name: <%= ENV['AWS_IAM_INSTANCE_PROFILE_1'] %>
       image_search:
         owner-id: 099720109477
-        name: ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-20190913
+        name: ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-20210928
       instance_initiated_shutdown_behavior: terminate
       instance_type: t3.micro
       name: ec2
-      region: <%= ENV.fetch('AWS_REGION', 'us-west-2') %>
+      region: <%= ENV['AWS_REGION'] %>
       security_group_ids:
-        - <%= ENV.fetch('AWS_SECURITY_GROUP_lnx_1', 'sg-00000000') %>
-        - <%= ENV.fetch('AWS_SECURITY_GROUP_lnx_2', 'sg-00000000') %>
-      subnet_id: <%= ENV.fetch('AWS_SUBNET_ID', 'subnet-00000000') %>
+        - <%= ENV['AWS_SECURITY_GROUP_1'] %>
+        <% if ENV['AWS_SECURITY_GROUP_2'] %>
+        - <%= ENV['AWS_SECURITY_GROUP_2'] %>
+        <% end %>
+        <% if ENV['AWS_SECURITY_GROUP_3'] %>
+        - <%= ENV['AWS_SECURITY_GROUP_3'] %>
+        <% end %>
+        <% if ENV['AWS_SECURITY_GROUP_4'] %>
+        - <%= ENV['AWS_SECURITY_GROUP_4'] %>
+        <% end %>
+        <% if ENV['AWS_SECURITY_GROUP_5'] %>
+        - <%= ENV['AWS_SECURITY_GROUP_5'] %>
+        <% end %>
+      subnet_id: <%= ENV['AWS_SUBNET_ID'] %>
       tags:
         Created-By: Test Kitchen
         OS: Ubuntu 16.04 LTS
         Owner: *aws_tag_owner
       # user_data: *bootstrap_lnx
-      vpc_id: <%= ENV.fetch('AWS_VPC_ID', 'vpc-00000000') %>
+      vpc_id: ENV['AWS_VPC_ID'] %>
     transport:
       username: ubuntu
-      ssh_key: <%= ENV.fetch('AWS_SSH_KEY_PATH', ENV['HOME'] + "/.ssh/bonusbits_dev_key.pem") %>
+      ssh_key: <%= ENV['AWS_SSH_KEY_PATH'] %>
   - name: ubuntu-1804-ami
     driver:
-      associate_public_ip: <%= ENV.fetch('AWS_PUBLIC_IP', 'false') %>
-      aws_ssh_key_id: <%= ENV.fetch('AWS_SSH_KEY_ID', 'bonusbits_dev_key') %>
-      iam_profile_name: <%= ENV.fetch('AWS_IAM_INSTANCE_PROFILE_LNX', 'Linux-Instance_Role') %>
+      associate_public_ip: <%= ENV['AWS_PUBLIC_IP'] %>
+      aws_ssh_key_id: <%= ENV['AWS_SSH_KEY_ID'] %>
+      iam_profile_name: <%= ENV['AWS_IAM_INSTANCE_PROFILE_1'] %>
       image_search:
         owner-id: 099720109477
-        name: ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20191002
+        name: ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20210907
       instance_initiated_shutdown_behavior: terminate
       instance_type: t3.micro
       name: ec2
-      region: <%= ENV.fetch('AWS_REGION', 'us-west-2') %>
+      region: <%= ENV['AWS_REGION'] %>
       security_group_ids:
-        - <%= ENV.fetch('AWS_SECURITY_GROUP_lnx_1', 'sg-00000000') %>
-        - <%= ENV.fetch('AWS_SECURITY_GROUP_lnx_2', 'sg-00000000') %>
-      subnet_id: <%= ENV.fetch('AWS_SUBNET_ID', 'subnet-00000000') %>
+        - <%= ENV['AWS_SECURITY_GROUP_1'] %>
+        <% if ENV['AWS_SECURITY_GROUP_2'] %>
+        - <%= ENV['AWS_SECURITY_GROUP_2'] %>
+        <% end %>
+        <% if ENV['AWS_SECURITY_GROUP_3'] %>
+        - <%= ENV['AWS_SECURITY_GROUP_3'] %>
+        <% end %>
+        <% if ENV['AWS_SECURITY_GROUP_4'] %>
+        - <%= ENV['AWS_SECURITY_GROUP_4'] %>
+        <% end %>
+        <% if ENV['AWS_SECURITY_GROUP_5'] %>
+        - <%= ENV['AWS_SECURITY_GROUP_5'] %>
+        <% end %>
+      subnet_id: <%= ENV['AWS_SUBNET_ID'] %>
       tags:
         Created-By: Test Kitchen
         OS: Ubuntu 18.04 LTS
         Owner: *aws_tag_owner
       # user_data: *bootstrap_lnx
-      vpc_id: <%= ENV.fetch('AWS_VPC_ID', 'vpc-00000000') %>
+      vpc_id: <%= ENV['AWS_VPC_ID'] %>
     transport:
       username: ubuntu
-      ssh_key: <%= ENV.fetch('AWS_SSH_KEY_PATH', ENV['HOME'] + "/.ssh/bonusbits_dev_key.pem") %>
+      ssh_key: <%= ENV['AWS_SSH_KEY_PATH'] %>
+  - name: ubuntu-2004-ami
+    driver:
+      associate_public_ip: <%= ENV['AWS_PUBLIC_IP'] %>
+      aws_ssh_key_id: <%= ENV['AWS_SSH_KEY_ID'] %>
+      iam_profile_name: <%= ENV['AWS_IAM_INSTANCE_PROFILE_1'] %>
+      image_search:
+        owner-id: 099720109477
+        name: ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20211001
+      instance_initiated_shutdown_behavior: terminate
+      instance_type: t3.micro
+      name: ec2
+      region: <%= ENV['AWS_REGION'] %>
+      security_group_ids:
+        - <%= ENV['AWS_SECURITY_GROUP_1'] %>
+        <% if ENV['AWS_SECURITY_GROUP_2'] %>
+        - <%= ENV['AWS_SECURITY_GROUP_2'] %>
+        <% end %>
+        <% if ENV['AWS_SECURITY_GROUP_3'] %>
+        - <%= ENV['AWS_SECURITY_GROUP_3'] %>
+        <% end %>
+        <% if ENV['AWS_SECURITY_GROUP_4'] %>
+        - <%= ENV['AWS_SECURITY_GROUP_4'] %>
+        <% end %>
+        <% if ENV['AWS_SECURITY_GROUP_5'] %>
+        - <%= ENV['AWS_SECURITY_GROUP_5'] %>
+        <% end %>
+      subnet_id: <%= ENV['AWS_SUBNET_ID'] %>
+      tags:
+        Created-By: Test Kitchen
+        OS: Ubuntu 18.04 LTS
+        Owner: *aws_tag_owner
+      # user_data: *bootstrap_lnx
+      vpc_id: <%= ENV['AWS_VPC_ID'] %>
+    transport:
+      username: ubuntu
+      ssh_key: <%= ENV['AWS_SSH_KEY_PATH'] %>
 
   # Docker Platforms
   - name: amazon-linux1-docker

--- a/Berksfile.lock
+++ b/Berksfile.lock
@@ -4,10 +4,10 @@ DEPENDENCIES
     metadata: true
 
 GRAPH
-  apt (7.2.0)
-  audit (9.0.1)
+  apt (7.4.0)
+  audit (9.5.0)
   bonusbits_base (3.0.2)
     apt (>= 0.0.0)
     audit (>= 0.0.0)
     selinux (>= 0.0.0)
-  selinux (3.0.1)
+  selinux (6.0.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## CHANGE LOG
 
+## 3.0.3 - 10/04/2020 - Levon Becker
+* Improved kitchen config
+  * Removed env var defaults from kitchen config. If at a place where that makes since then can add, otherwise it's just confusing when you're missing an env var and it bombs with an odd error. This way it will be in your face that it's looking for an env var that is missing.
+  * Updated Amazon Linux 1/2 AMI to latest
+  * Updated Ubuntu 16/18 AMI to latest
+  * Added Ubuntu 20.04 AMI
+
 ## 3.0.2 - 03/19/2020 - Levon Becker
 * Renamed inspec_bonusbits_base repo to bonusbits_base_inspec in github. So, needed to updated audit and kitchen config
 * Moved todo list to TODO.md

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 Bonus Bits
+Copyright (c) 2021 Bonus Bits
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Bonus Bits Base Cookbook
-[![Project Release](https://img.shields.io/badge/release-v3.0.2-blue.svg)](https://github.com/bonusbits/bonusbits_base)
+[![Project Release](https://img.shields.io/badge/release-v3.0.3-blue.svg)](https://github.com/bonusbits/bonusbits_base)
 [![Circle CI](https://circleci.com/gh/bonusbits/bonusbits_base/tree/master.svg?style=shield)](https://circleci.com/gh/bonusbits/bonusbits_base/tree/master)
 [![Join the chat at https://gitter.im/bonusbits/bonusbits_base](https://badges.gitter.im/bonusbits/bonusbits_base.svg)](https://gitter.im/bonusbits/bonusbits_base?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![GitHub issues](https://img.shields.io/github/issues/bonusbits/bonusbits_base.svg)](https://github.com/bonusbits/bonusbits_base/issues)
@@ -107,12 +107,12 @@ Basically copy/paste, instead of converting YAML to JSON... I've done it for you
 ```
 test
 ├── data_bags
-│   ├── encrypted_data_bag_secret
-│   └── bonusbits_base
-│       ├── credentials.json
-│       └── enterprise_ca.json
+│         ├── encrypted_data_bag_secret
+│         └── bonusbits_base
+│             ├── credentials.json
+│             └── enterprise_ca.json
 ├── environments
-│   └── bonusbits_base.json
+│         └── bonusbits_base.json
 └── node
     └── client.rb
 └── roles

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'levon.becker.github@bonusbits.com'
 license 'MIT'
 description 'Foundation Wrapper Cookbook for all Nodes'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '3.0.2'
+version '3.0.3'
 chef_version '~> 15.4' if respond_to?(:chef_version)
 source_url 'https://github.com/bonusbits/bonusbits_base'
 issues_url 'https://github.com/bonusbits/bonusbits_base/issues'


### PR DESCRIPTION
* Improved kitchen config
  * Removed env var defaults from kitchen config. If at a place where that makes since then can add, otherwise it's just confusing when you're missing an env var and it bombs with an odd error. This way it will be in your face that it's looking for an env var that is missing.
  * Updated Amazon Linux 1/2 AMI to latest
  * Updated Ubuntu 16/18 AMI to latest
  * Added Ubuntu 20.04 AMI